### PR TITLE
Fixed two related bugs in the `delete_vector` callback-function, with two known bugs.

### DIFF
--- a/code/main.py
+++ b/code/main.py
@@ -197,12 +197,14 @@ class MatrixTransformationsApp:
             if not name:
                 name = list(stored_vectors.keys())[-1]
             if name not in stored_vectors:
-                return create_figure(stored_vectors), stored_vectors
+                return (create_figure(stored_vectors),
+                        stored_vectors,
+                        previous_vectors)
 
             del stored_vectors[name]
             for vectors in previous_vectors:
                 try:
-                    vectors[name]
+                    del vectors[name]
                 except KeyError:  # Doesn't matter, just keep deleting.
                     continue
 


### PR DESCRIPTION
### 1. The first bug fix: 
When the user attempts to delete a vector with a name that isn't in `vector-store`, it breaks, and the error shows that it was attempting to pass data (that it's not supposed to) into the `create_figure` function to make the graph.

Why that happened and the solution:
I forgot to return `previous_vectors` along with the rest of the variables when handling the case where the user tries to delete a non-existent vector. So I passed it in. It's literally a one-liner fix.


### 2. The second bug fix: 
The bug was when the user does these things in order: i. Adds a vector,
ii. Adds any matrix,
iii. Deletes that vector,
iv. Undoes the matrix;
the deleted vector suddenly reappears.

Why that happened and the solution:
I forgot to include the del statement in the for-loop that deleted the vectors in stored vectors in the `delete_vector` callback-function, causing it to check if the vectors are there instead of actually deleting them. So I simply included it.

Both of the above bugfixes address issues within `delete_vector` to decrease unpredictable behavior due to oversights.


### 3. The two bugs in the commit:
The first bug is related to the `add_or_edit_vector` callback-function. If the user leaves the vector-xy-values inputs blank in the app, wrong values are inputted for the arguments for `x_val` and `y_val` (None instead of 0) in `add_or_edit_vector`.

The second bug is related to the edit-vector safe-net, where if the user does these things in order: i. Adds a vector with values inside the vector-entry-inputs, ii. Adds two invertible matrices (whether it be the same one or otherwise), iii. Edits the vector,
iv. Undoes the matrices twice;
the vector gets visually undone (aka gets applied the inverse transformation) only once, leaving it visually inconsistent after the first undo. This actually generalizes to when the user applies multiple matrices too, only keeping the edited vector visually consistent after the first undo.


### 4. Misc. notes:
- The commented-and-unused `_handle_unupdated_vectors` handler function is still there for the same reasons (repurpose-able for later refactoring).