### PR TITLE
Fixed a bug in the edit-vector safe-net, with another known bug. (now resolved via a recent merging of a pull request)

### DIFF
--- a/code/main.py
+++ b/code/main.py
@@ -197,12 +197,14 @@ class MatrixTransformationsApp:
             if not name:
                 name = list(stored_vectors.keys())[-1]
             if name not in stored_vectors:
-                return create_figure(stored_vectors), stored_vectors
+                return (create_figure(stored_vectors),
+                        stored_vectors,
+                        previous_vectors)
 
             del stored_vectors[name]
             for vectors in previous_vectors:
                 try:
-                    vectors[name]
+                    del vectors[name]
                 except KeyError:  # Doesn't matter, just keep deleting.
                     continue
 


### PR DESCRIPTION
The bug:
When the user adds a vector, then applies a uninversible matrix, then edits the vector, then attempts to undo the matrix, an error message pops up with the message "Too little values to unpack (expected 3, got 2)" due to an oversight in returning values for `previous_stored_vectors`.
Essentially, all that happened was that there was an oversight where it didn't re-format the edited-vector (only included the values, without the color) before giving it back to 'previous-vector-storage`.

The solution:
Found and fixed the code that was passing in the improperly formatted vector.

The bug in the commit:
When the user attempts to delete a vector with a name that isn't in `vector-store`, it breaks, and the error shows that it was attempting to pass data (that it's not supposed to) into the `create_figure` function to make the graph.

Misc. notes:
- Removed the print statements from the last commit.
- Kept the unused `_handle_unupdated_vectors` handler function commented for later refactoring.
