### PR TITLE
Fix a bug in `add_or_edit_vector`, w/ known bug.

### DIFF
--- a/code/main.py
+++ b/code/main.py
@@ -151,6 +151,7 @@ class MatrixTransformationsApp:
                 reversed(previous_vectors.copy())
             )
             new_previous_vectors = most_to_least_recent_prev_vecs.copy()
+            previous_vectors_temp = None
             for vectors, (its_matrixs_name, its_matrix) in zip(
                     new_previous_vectors,
                     matrices.items()
@@ -159,14 +160,23 @@ class MatrixTransformationsApp:
                     break
                 inverse_matrix = safe_inverse(its_matrix)
                 if inverse_matrix is not None:
-                    edited_vector = np.array([x, y])
+                    edited_vector = np.array([x, y]) if (
+                        previous_vectors_temp is None) else (
+                        previous_vectors_temp)
                     inverted_edited_vector_vals = (
-                            inverse_matrix @ edited_vector).tolist()
-                    inverted_edited_vector = [inverted_edited_vector_vals,
-                                              color]
+                            inverse_matrix @ edited_vector)
+                    previous_vectors_temp = inverted_edited_vector_vals.copy()
+                    inverted_edited_vector = [
+                        inverted_edited_vector_vals.tolist(),
+                        color
+                    ]
                     vectors[vector_name] = inverted_edited_vector
                 else:
-                    vectors[vector_name] = [(x, y), color]
+                    edited_vector = [(x, y), color] if (
+                            previous_vectors_temp is None) else (
+                            previous_vectors_temp)
+                    vectors[vector_name] = edited_vector
+
                     new_output_logs += (
                         f'Edited vector "{vector_name}" was unable to be '
                         f'properly shown before the matrix '
@@ -635,8 +645,8 @@ class MatrixTransformationsApp:
                       'height': '500px'})
         ])
 
+    @staticmethod
     def _vector_getter(
-            self,
             x_val: Number,
             y_val: Number
     ) -> tuple[Number, Number]:


### PR DESCRIPTION
### 1. Bug description: 
Steps to reproduce:
i. Adds a vector,
ii. Adds two invertible matrices (whether they be the same or otherwise), 
iii. Edits the vector,
iv. Undoes the matrices twice;
the vector gets visually undone (aka gets applied the inverse transformation) only once, leaving it visually inconsistent after the first undo. This actually generalizes to when the user applies multiple matrices too, only keeping the edited vector visually consistent after the first undo.

This is because when it loops from the end of the list `previous_vectors` to edit its vectors, it only edits each of those vectors into the exact same inverse of the edited_vectors, thus only remaining visually consistent after one undo.


### 2. Solution: 
Add a variable which gets assigned as the new inverted edited vector with each loop (if there's an inverse in that loop) so that the program can update the vectors correctly.


### 3. Bug in the commit:
When doing this:
i. Add a vector,
ii. Apply a non-invertible matrix,
iii. Apply an invertible matrix,
iv. Edit that vector,
v. Undo the second matrix,
vi. Undo the first matrix,
a `TypeError: cannot unpack non-iterable float object` gets raised when attempting to undo the non-invertible matrix.


### 4. Misc. notes:
- Change `_vector_getter` into a static method since it no longer needed the parameter `self`.
- The commented-and-unused `_handle_unupdated_vectors` handler function is still there for the same reasons (repurpose-able for later refactoring for the edit-vector safe-net code).