### PR TITLE
Fix bug in `add_or_edit_vector`.

### DIFF
--- a/code/main.py
+++ b/code/main.py
@@ -172,16 +172,23 @@ class MatrixTransformationsApp:
                     ]
                     vectors[vector_name] = inverted_edited_vector
                 else:
+                    if previous_vectors_temp is not None:
+                        previous_vectors_temp_vector = [
+                            previous_vectors_temp.tolist(),
+                            color
+                        ]
+                    else:
+                        previous_vectors_temp_vector = None
                     edited_vector = [(x, y), color] if (
-                            previous_vectors_temp is None) else (
-                            previous_vectors_temp)
+                            previous_vectors_temp_vector is None) else (
+                            previous_vectors_temp_vector)
                     vectors[vector_name] = edited_vector
 
                     new_output_logs += (
                         f'Edited vector "{vector_name}" was unable to be '
                         f'properly shown before the matrix '
-                        f'"{its_matrixs_name}" was applied due to that '
-                        f'matrix being singular. '
+                        f'"{its_matrixs_name}" was applied due to it being '
+                        f'singular. '
                     )
             return (create_figure(stored_vectors),
                     stored_vectors,


### PR DESCRIPTION
1. Bug Description: a. Steps to reproduce: i. Add a vector, ii. Apply a non-invertible matrix, iii. Apply an invertible matrix, iv. Edit that vector, v. Undo the second matrix, vi. Undo the first matrix, Result: `TypeError: cannot unpack non-iterable float object` is raised when attempting to undo the non-invertible matrix.

   b. Cause: When facing a non-invertible matrix, `add_or_edit_vector` was passing in a list with only the xy-values of the edited vector, without the variable `color` that should have been included. This caused ausing `create_figures` to crash.

   c. Solution: Add a variable to put that list of xy-values into the proper format of type `Vector` with `color` for the function to use.

2. Sidenote: In the process of testing this bugfix, another bug was encountered caused by the initial fix. Steps to reproduce: i. Add a non-invertible matrix. ii. Add a vector. iii. Add another non-invertible matrix. iv. Attempt to edit the vector. Result: `AttributeError: 'NoneType' object has no attribute 'tolist'` is raised when attempting to edit the vector.
   
   Cause: The initial bugfix tried to use the method `.tolist()` on `previous_vectors_temp`, without a `None` check.
 
   Solution: Added a None check, changing the code of the original bugfix from: ``` previous_vectors_temp_vector = [ previous_vectors_temp.tolist(), color ] ``` To: ``` if previous_vectors_temp is not None: previous_vectors_temp_vector = [ previous_vectors_temp.tolist(), color ] else: previous_vectors_temp_vector = None ```

3. Misc. note:
- Slightly changed the output log of the last else-statement to get a slightly shorter message.
- The commented-and-unused `_handle_unupdated_vectors` handler function is still there for the same reasons (repurpose-able for later refactoring for the edit-vector safe-net code).