### PR TITLE
Implement Repeat Last Matrix Feature

### DIFF
--- a/code/main.py
+++ b/code/main.py
@@ -629,6 +629,23 @@ class MatrixTransformationsApp:
                 stored_matrices
             )
 
+            stored_matrices[new_name] = stored_matrices[selected_matrix]
+            previous_vectors.append(stored_vectors.copy())
+            new_vectors = self.apply_matrix_to_vectors(
+                stored_matrices[selected_matrix],
+                stored_vectors
+            )
+            matrix_list = str({f'{name}': mat
+                               for name, mat in stored_matrices.items()})
+
+            return (stored_matrices,
+                    matrix_list,
+                    create_figure(new_vectors),
+                    new_vectors,
+                    previous_vectors,
+                    {},
+                    output_logs)
+
         @self.app.callback(
             Output('add-vector-button', 'children'),
             [Input('new-vector-entry-name', 'value'),


### PR DESCRIPTION
## Summary
This PR adds a button and entry to repeat matrices and their respective functionalities.
Resolves #10.

## Details 
1. **Context**:
   This PR addresses the need for a button (and entry) to repeat any chosen matrix, detailed in #10.
2. **Implementation**:
   - By default (with a blank entry), the repeated matrix's name will be in the format `name + ' (<appropriate int>)'`.
   - There are no other significant design choices.
3. **Testing**:
   - Manual testing was performed to ensure correct application of repeated transformations. 
   - Tested edge cases such as no matrices and attempting to repeat a non-existent matrix.
   - No automated tests were implemented as they are currently not needed.
4. **Known Issues**:
   None.
5. **Development Process**:
    1. Add horizontal line (as a separator), an entry, and a button to the UI.
    2. Implement handling of edge-cases.
    3. Developed a method to generate a unique name for the repeated matrix.
    4. Implement applying the most recent matrix.
    5. Tested for bugs.
6. **Additional Context**:
   - The function `_generate_unique_matrix_name` used in the main function inside this feature (`repeat_matrix`) could be refactored in the future to be a general function for finding a unique matrix name.

## Screenshots/Recordings
New horizontal line, button, and entry under the `Redo Last Matrix` button.
![image](https://github.com/user-attachments/assets/0d164c53-adaf-44e0-bb5d-4768bb2fb9e2)