### PR TITLE
Fix bug in `undo_matrix` function.

### DIFF
--- a/code/main.py
+++ b/code/main.py
@@ -473,7 +473,7 @@ class MatrixTransformationsApp:
             restored_vectors = new_previous_vectors.pop()
 
             return (new_stored_matrices,
-                    str(stored_matrices),
+                    str(new_stored_matrices),
                     create_figure(restored_vectors),
                     restored_vectors,
                     new_previous_vectors,


### PR DESCRIPTION
## Summary
This PR fixes the bug detailed in #16.
Fixes #16.

## Details 
1. **Context**:
   The issue was that the matrix-list was not updating correctly when the Undo and Redo Matrix buttons were pressed. This bug required each button to be pressed twice for the list to update, which was inconsistent with the expected behavior.
2. **Implementation**:
   There were no significant decisions made in this PR.
   The bug was traced to a typo where the variable `stored_matrices` was mistakenly converted to a string instead of the variable `new_stored_matrices`. This PR corrects that typo.
3. **Testing**:
   The fix was tested by replicating the bug scenarios described in the issue and confirming that the matrix-list updates correctly with a single press of the Undo or Redo Matrix buttons.
4. **Known Issues**:
   N/A.
5. **Development Process**:
   The majority of the development process was spent on tracing the typo that caused it.
    1. Conducted a search to find which commit change caused this issue.
    2. Identified the 4-letter typo in the `undo_matrix` function.
    3. Corrected the variable conversion.
    4. Verified the fix by testing the button functionality.
6. **Additional Context**:
    - This fix ensures that `matrix-list` is now in sync with the graph transformations as intended.
    - This fix is inconsequential to the core functionality of the program.

## Screenshots/Recordings
N/A