### PR TITLE
Add animations for undoing matrices, whether they are invertable or not.

### DIFF
--- a/code/layout_sections/graph_section.py
+++ b/code/layout_sections/graph_section.py
@@ -15,7 +15,7 @@ def create_graph_section(app) -> html.Section:
             dcc.Store(id="animation-steps", data=[]),
             dcc.Store(
                 id="animation-undo-mode",
-                data={"is_undo": False, "has_inverse": True},
+                data=False,
             ),
             dcc.Graph(
                 id="graph",


### PR DESCRIPTION
## Summary

This PR adds animations to the undo feature within the project.
Resolves #19.

## Details 
1. **Context**:
   Given that this repository helps in visualizing matrices, it'd help even more if undoing matrices, even uninvertible ones, are to be animated.
2. **Implementation**:
   It was necessary to add a new boolean parameter stored as `undo_mode` for the `animate_graph` function to use. This only describes whether or not the last operation was an undo operation. `animate_graph` handles playing animations backwards for undoing matrices, and the function `undo_matrices` just gives it the steps.
3. **Testing**:
   Changes were tested visually to make sure animations behaved as intended.
4. **Known Issues**:
   N/A

## Screenshots/Recordings

![Undo Animations Showcase](https://github.com/user-attachments/assets/ee7969fa-1898-46c0-917c-9f727e2cda24)
