### PR TITLE
Fix naming scheme of inverted and duplicated matrices.

### DIFF
--- a/src/callbacks/matrix.py
+++ b/src/callbacks/matrix.py
@@ -1,13 +1,13 @@
 import numpy as np
-from src.types import Matrix, MatrixDict, Vectors, Number
+from dash import no_update
 from dash.dependencies import Input, Output, State
+from src.types import Matrix, MatrixDict, Vectors, Number
 from src.utils.matrix import (
     apply_matrix_to_vectors,
+    generate_duplicate_matrix_name,
+    generate_new_matrix_name,
     safe_inverse,
 )
-from src.config.constants import UPPER_LETTERS
-from dash import no_update
-from src.utils.matrix import generate_unique_matrix_name
 from src.utils.general import set_nonetype_to_zero
 
 
@@ -48,9 +48,7 @@ def register_matrix_callbacks(app_instance):
         Output("animation-interval", "disabled", allow_duplicate=True),
         Output("animation-steps", "data", allow_duplicate=True),
         [
-            Input(
-                {"type": "interactable", "name": "add-matrix-button"}, "n_clicks"
-            ),
+            Input({"type": "interactable", "name": "add-matrix-button"}, "n_clicks"),
             State({"type": "interactable", "name": "matrix-entry-1"}, "value"),
             State({"type": "interactable", "name": "matrix-entry-2"}, "value"),
             State({"type": "interactable", "name": "matrix-entry-3"}, "value"),
@@ -60,15 +58,13 @@ def register_matrix_callbacks(app_instance):
             State("matrix-store", "data"),
             State("vector-store", "data"),
             State("previous-vector-store", "data"),
-            State(
-                {"type": "interactable", "name": "new-matrix-entry-name"}, "value"
-            ),
+            State({"type": "interactable", "name": "new-matrix-entry-name"}, "value"),
         ],
         [State("animation-steps", "data")],
         prevent_initial_call=True,
     )
     def add_matrix(
-        n_clicks: int,
+        _: int,
         a: Number,
         b: Number,
         c: Number,
@@ -82,16 +78,16 @@ def register_matrix_callbacks(app_instance):
         a, b, c, d = set_nonetype_to_zero(a, b, c, d)
 
         matrix = np.array([[a, b], [c, d]])
-        matrix_name = name if name else UPPER_LETTERS[n_clicks % 26 - 1]
+        matrix_name = (
+            name if name else generate_new_matrix_name(list(stored_matrices.keys()))
+        )
 
         stored_matrices[matrix_name] = matrix.tolist()
 
         previous_vectors.append(stored_vectors.copy())
 
         most_recent_matrix = np.array(list(stored_matrices.values())[-1])
-        new_vectors = apply_matrix_to_vectors(
-            most_recent_matrix, stored_vectors
-        )
+        new_vectors = apply_matrix_to_vectors(most_recent_matrix, stored_vectors)
 
         new_steps = app_instance.update_animations(
             animation_steps=animation_steps.copy(), end_matrix=most_recent_matrix
@@ -196,15 +192,13 @@ def register_matrix_callbacks(app_instance):
         #     inverse_name = "(" + name + ")^{-1}"
         # else:
         #     inverse_name = name + r"^{-1}"
-        new_name = generate_unique_matrix_name(
-            name=inverse_name, existing_names=stored_matrices
+        new_name = generate_duplicate_matrix_name(
+            name=inverse_name, existing_names=list(stored_matrices.keys())
         )
 
         stored_matrices[new_name] = inverted_matrix.tolist()
         previous_vectors.append(stored_vectors.copy())
-        new_vectors = apply_matrix_to_vectors(
-            inverted_matrix, stored_vectors
-        )
+        new_vectors = apply_matrix_to_vectors(inverted_matrix, stored_vectors)
 
         most_recent_matrix = np.array(stored_matrices[new_name])
         new_steps = app_instance.update_animations(
@@ -271,10 +265,8 @@ def register_matrix_callbacks(app_instance):
 
         # This is done so that it doesn't delete any vectors that were made
         # before the undoing.
-        new_previous_vectors, output_log_updates = (
-            _handle_newly_added_vectors(
-                new_stored_vectors, new_previous_vectors, inverse_matrix
-            )
+        new_previous_vectors, output_log_updates = _handle_newly_added_vectors(
+            new_stored_vectors, new_previous_vectors, inverse_matrix
         )
 
         new_undone_matrices[last_matrix_name] = new_stored_matrices.pop(
@@ -357,9 +349,7 @@ def register_matrix_callbacks(app_instance):
         previous_vectors.append(stored_vectors.copy())
 
         most_recent_matrix = np.array(stored_matrices[last_undone_matrix_name])
-        restored_vectors = apply_matrix_to_vectors(
-            most_recent_matrix, stored_vectors
-        )
+        restored_vectors = apply_matrix_to_vectors(most_recent_matrix, stored_vectors)
 
         new_steps = app_instance.update_animations(
             animation_steps=animation_steps.copy(), end_matrix=most_recent_matrix
@@ -434,7 +424,9 @@ def register_matrix_callbacks(app_instance):
         if not selected_matrix:
             selected_matrix = list(stored_matrices.keys())[-1]
 
-        new_name = generate_unique_matrix_name(selected_matrix, stored_matrices)
+        new_name = generate_duplicate_matrix_name(
+            selected_matrix, list(stored_matrices.keys())
+        )
 
         stored_matrices[new_name] = stored_matrices[selected_matrix]
         previous_vectors.append(stored_vectors.copy())


### PR DESCRIPTION
## Summary
This PR fixes the naming scheme of inverse and duplicate matrices.
Resolves #34.

## Details 
1. **Context**:
   The current naming scheme does not follow standard mathematical notation. Details in #34.
2. **Implementation**:
   The logic for this uses manual string manipulation with the `re` module. The functions are stored in the file `src/utils/matrix.py` file.
3. **Testing**:
   Changes were tested manually.
4. **Known Issues**:
   Currently, this implementation would be unscalable due how the underlying data structure doesn't contain metadata about the matrix--because it's just a dictionary.
5. **Additional Context**:
   This change makes me consider changing the `Matrix` and `Vectors` data structures within the project, since to add more matrix controls would require more types of matrices, and that just wouldn't be fun or sane to deal with when, currently, matrix metadata is stored in the name of the matrix itself.

## Screenshots/Recordings
<div>
<img width="130" height="182" alt="image" src="https://github.com/user-attachments/assets/c351cec8-c35f-4914-a20e-481ea877bccc" />
<img width="162" height="189" alt="image" src="https://github.com/user-attachments/assets/8c72b0a3-fcd8-4b6e-b1cc-436edffcfcf5" />
</div>